### PR TITLE
Add setSpeedLimit condition

### DIFF
--- a/nav2_mppi_controller/src/optimizer.cpp
+++ b/nav2_mppi_controller/src/optimizer.cpp
@@ -433,7 +433,7 @@ void Optimizer::setSpeedLimit(double speed_limit, bool percentage)
       s.constraints.vx_min = s.base_constraints.vx_min * ratio;
       s.constraints.vy = s.base_constraints.vy * ratio;
       s.constraints.wz = s.base_constraints.wz * ratio;
-    } else {
+    } else if (speed_limit < s.base_constraints.vx_max) {
       // Speed limit is expressed in absolute value
       double ratio = speed_limit / s.base_constraints.vx_max;
       s.constraints.vx_max = s.base_constraints.vx_max * ratio;


### PR DESCRIPTION
Add condition for MPPI controller to setSpeedLimit in order to filter out the speed filter's large values.
It is similar to the DWB implementation (https://github.com/ros-planning/navigation2/blob/0be2f25782413677fedc58ea090c6ecfa8b9a6b8/nav2_dwb_controller/dwb_plugins/src/kinematic_parameters.cpp#L147)

Note:
Once a small filter value is received, if a larger value exceeds the controller's base maximum velocity, the controller will maintain the smaller value rather than resorting to the base maximum velocity.