### PR TITLE
add createTreeFromFile

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -214,13 +214,9 @@ bool BtActionServer<ActionT>::loadBehaviorTree(const std::string & bt_xml_filena
     return false;
   }
 
-  auto xml_string = std::string(
-    std::istreambuf_iterator<char>(xml_file),
-    std::istreambuf_iterator<char>());
-
   // Create the Behavior Tree from the XML input
   try {
-    tree_ = bt_->createTreeFromText(xml_string, blackboard_);
+    tree_ = bt_->createTreeFromFile(filename, blackboard_);
     for (auto & blackboard : tree_.blackboard_stack) {
       blackboard->set<rclcpp::Node::SharedPtr>("node", client_node_);
       blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);


### PR DESCRIPTION
Make changes to be able to include xml bt-s with relative path.
According to this PR:  [ Migrate to createTreeFromFile for loading BTs #3306 ](https://github.com/ros-navigation/navigation2/pull/3306)
Which addresses this issues: [  BTActionServer always loads behavior tree XML files from text, which breaks relative includes in the XML #3210  ](https://github.com/ros-navigation/navigation2/issues/3210)