### PR TITLE
Fix max_points param usage in collision_detector

### DIFF
--- a/nav2_collision_monitor/src/collision_detector_node.cpp
+++ b/nav2_collision_monitor/src/collision_detector_node.cpp
@@ -314,8 +314,7 @@ void CollisionDetector::process()
   for (std::shared_ptr<Polygon> polygon : polygons_) {
     state_msg->polygons.push_back(polygon->getName());
     state_msg->detections.push_back(
-      polygon->getPointsInside(
-        collision_points) > polygon->getMaxPoints() + 1);
+      polygon->getPointsInside(collision_points) > polygon->getMaxPoints());
   }
 
   state_pub_->publish(std::move(state_msg));


### PR DESCRIPTION
The collision_detector node used the `max_points` differently than the collision_monitor and as the documentation states.
This bug was introduced with the node's backport.

