### PR TITLE
Remove source timestamp differ warning

### DIFF
--- a/nav2_collision_monitor/src/source.cpp
+++ b/nav2_collision_monitor/src/source.cpp
@@ -82,11 +82,6 @@ bool Source::sourceValid(
   // than current time by source_timeout_ interval
   const rclcpp::Duration dt = curr_time - source_time;
   if (dt > source_timeout_) {
-    RCLCPP_WARN(
-      logger_,
-      "[%s]: Latest source and current collision monitor node timestamps differ on %f seconds. "
-      "Ignoring the source.",
-      source_name_.c_str(), dt.seconds());
     return false;
   }
 


### PR DESCRIPTION
This PR removes a warning print which becomes annoying if a source is turned off intentionally. This is a sub-optimal solution.
