### PR TITLE
[REMOVEME] Use latest transform instead of node's time in rotation_shim_controller

### DIFF
--- a/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
@@ -240,7 +240,10 @@ geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathPt()
     dy = current_path_.poses[i].pose.position.y - start.position.y;
     if (hypot(dx, dy) >= forward_sampling_distance_) {
       current_path_.poses[i].header.frame_id = current_path_.header.frame_id;
-      current_path_.poses[i].header.stamp = rclcpp::Time(0); // Latest available transform
+      // TODO: This is a hack to use the latest transform, instead of the clock time
+      // When we use the clock time, we have to wait for the transform to be available
+      // which depending on the odom frequency can be a problem
+      current_path_.poses[i].header.stamp = rclcpp::Time(0);
       return current_path_.poses[i];
     }
   }
@@ -259,7 +262,10 @@ geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathGoal()
 
   auto goal = current_path_.poses.back();
   goal.header.frame_id = current_path_.header.frame_id;
-  goal.header.stamp = rclcpp::Time(0);  // Latest available transform
+  // TODO: This is a hack to use the latest transform, instead of the clock time
+  // When we use the clock time, we have to wait for the transform to be available
+  // which depending on the odom frequency can be a problem
+  goal.header.stamp = rclcpp::Time(0);
   return goal;
 }
 

--- a/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
+++ b/nav2_rotation_shim_controller/src/nav2_rotation_shim_controller.cpp
@@ -240,7 +240,7 @@ geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathPt()
     dy = current_path_.poses[i].pose.position.y - start.position.y;
     if (hypot(dx, dy) >= forward_sampling_distance_) {
       current_path_.poses[i].header.frame_id = current_path_.header.frame_id;
-      current_path_.poses[i].header.stamp = clock_->now();  // Get current time transformation
+      current_path_.poses[i].header.stamp = rclcpp::Time(0); // Latest available transform
       return current_path_.poses[i];
     }
   }
@@ -259,7 +259,7 @@ geometry_msgs::msg::PoseStamped RotationShimController::getSampledPathGoal()
 
   auto goal = current_path_.poses.back();
   goal.header.frame_id = current_path_.header.frame_id;
-  goal.header.stamp = clock_->now();
+  goal.header.stamp = rclcpp::Time(0);  // Latest available transform
   return goal;
 }
 


### PR DESCRIPTION
Temporary solution till we have a higher frequency odometry source. Right now we have to wait too long before we get the appropriate transform between odom and base_link (20-30 ms).