### PR TITLE
fix(docking): only flip backward dock orientation when yaw error exceeds 90deg

### DIFF
--- a/nav2_docking/opennav_docking/src/docking_server.cpp
+++ b/nav2_docking/opennav_docking/src/docking_server.cpp
@@ -442,11 +442,18 @@ bool DockingServer::approachDock(Dock * dock, geometry_msgs::msg::PoseStamped & 
     target_pose.pose.position.y += sin(yaw) * backward_projection;
     tf2_buffer_->transform(target_pose, target_pose, base_frame_);
 
-    // Make sure that the target pose is pointing at the robot when moving backwards
-    // This is to ensure that the robot doesn't try to dock from the wrong side
+    // Make sure that the target pose is pointing at the robot when moving backwards.
+    // Only flip orientation when needed, otherwise keep the detected heading.
     if (dock_backwards_) {
-      target_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(
-        tf2::getYaw(target_pose.pose.orientation) + M_PI);
+      const double target_yaw = tf2::getYaw(target_pose.pose.orientation);
+      const double yaw_to_robot = std::atan2(
+        -target_pose.pose.position.y, -target_pose.pose.position.x);
+      const double yaw_error = angles::shortest_angular_distance(target_yaw, yaw_to_robot);
+      if (std::abs(yaw_error) > M_PI_2) {
+        target_pose.pose.orientation = nav2_util::geometry_utils::orientationAroundZAxis(
+          target_yaw + M_PI);
+      }
+
     }
 
     // Compute and publish controls


### PR DESCRIPTION
The unconditional +M_PI flip (introduced in #4530) causes the robot to rotate away from the dock when the detected pose orientation is already roughly pointing toward the robot after transforming to base_frame.

Instead, compute the actual yaw error between the target orientation and the direction back to the robot, and only flip when that error exceeds M_PI_2. This matches the intent of the original fix without breaking cases where the orientation is already correct.
